### PR TITLE
:art: 구글로그인모달 공통컴포넌트화

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,15 +3,8 @@ import logo from '../assets/logo.svg';
 import Typography from './Typography';
 import { Link } from 'react-router-dom';
 import { Btn60 } from './Button';
-import ReactModal from 'react-modal';
 import { useState } from 'react';
-import {
-  IconWrapper,
-  ModalContent,
-  ModalOpen,
-} from '../pages/Login/components/Modal';
-import closeIcon from '../assets/icons/close.svg';
-import { Img } from '../assets/styles/styles';
+import LoginModal from './LoginModal';
 
 interface login {
   isLogin: boolean;
@@ -46,34 +39,7 @@ const Header = ({ isLogin }: login) => {
         )}
 
         {/* modal */}
-        <ReactModal
-          ariaHideApp={false}
-          isOpen={modalOpen}
-          onRequestClose={() => setModalOpen(false)}
-          style={{
-            overlay: {
-              position: 'fixed',
-              background: 'rgba(0, 0, 0, 0.3)',
-            },
-            content: {
-              margin: 'auto',
-              width: '815px',
-              height: '495px',
-              background: 'var(--type-white)',
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              borderRadius: '20px',
-            },
-          }}
-        >
-          <ModalOpen>
-            <IconWrapper onClick={() => setModalOpen(false)}>
-              <Img src={closeIcon} />
-            </IconWrapper>
-            <ModalContent />
-          </ModalOpen>
-        </ReactModal>
+        <LoginModal modalOpen={modalOpen} setModalOpen={setModalOpen} />
       </Container>
     </Wrapper>
   );
@@ -108,32 +74,3 @@ const Row = styled.div<{ gap?: string }>`
   align-items: center;
   height: 100%;
 `;
-
-// const ani = keyframes`
-// 0% {
-//   width: 0%;
-// }
-// 100% {
-//   width: 60%;
-// }
-// `;
-
-// const NavLink = styled(Link)`
-//   height: 100%;
-//   display: flex;
-//   flex-direction: column;
-//   align-items: center;
-//   justify-content: center;
-
-//   &:after {
-//     content: '';
-//     width: 0%;
-//     height: 2px;
-//     background: var(--main-blue);
-//     // position: absolute;
-//     left: 0;
-//     bottom: 0;
-//     animation: ${ani} 0.5s 1;
-//     animation-fill-mode: forwards;
-//   }
-// `;

--- a/src/components/LoginModal/Component.tsx
+++ b/src/components/LoginModal/Component.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
-import { TextWrap } from '../../../assets/styles/styles';
-import TypoGraphy from '../../../components/Typography';
+import { TextWrap } from '../../assets/styles/styles';
+import TypoGraphy from '../Typography';
 import { GoogleButton } from './GoogleLogin';
 
 const ModalContent = () => {

--- a/src/components/LoginModal/GoogleLogin.tsx
+++ b/src/components/LoginModal/GoogleLogin.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 import GoogleLogin from 'react-google-login';
 import styled from 'styled-components';
-import TypoGraphy from '../../../components/Typography';
-import google from '../../../assets/icons/google.svg';
-import { Img, ImgContainer } from '../../../assets/styles/styles';
-import { SERVER } from '../../../network/config';
+import TypoGraphy from '../Typography';
+import google from '../../assets/icons/google.svg';
+import { Img, ImgContainer } from '../../assets/styles/styles';
+import { SERVER } from '../../network/config';
 
 const clientID: string = process.env.REACT_APP_CLIENT_ID as string;
 

--- a/src/components/LoginModal/index.tsx
+++ b/src/components/LoginModal/index.tsx
@@ -1,0 +1,39 @@
+import ReactModal from 'react-modal';
+import { IconWrapper, ModalContent, ModalOpen } from './Component';
+import closeIcon from '../../assets/icons/close.svg';
+import { Img } from '../../assets/styles/styles';
+
+const LoginModal = ({ modalOpen, setModalOpen }: any) => {
+  return (
+    <ReactModal
+      ariaHideApp={false}
+      isOpen={modalOpen}
+      onRequestClose={() => setModalOpen(false)}
+      style={{
+        overlay: {
+          position: 'fixed',
+          background: 'rgba(0, 0, 0, 0.3)',
+        },
+        content: {
+          margin: 'auto',
+          width: '815px',
+          height: '495px',
+          background: 'var(--type-white)',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          borderRadius: '20px',
+        },
+      }}
+    >
+      <ModalOpen>
+        <IconWrapper onClick={() => setModalOpen(false)}>
+          <Img src={closeIcon} />
+        </IconWrapper>
+        <ModalContent />
+      </ModalOpen>
+    </ReactModal>
+  );
+};
+
+export default LoginModal;

--- a/src/pages/Login/NoneLogin.tsx
+++ b/src/pages/Login/NoneLogin.tsx
@@ -2,12 +2,9 @@ import TypoGraphy from '../../components/Typography';
 import { Btn60 } from '../../components/Button';
 import styled from 'styled-components';
 import noneLoginBg from '../../assets/img/noneLoginBg.png';
-import ReactModal from 'react-modal';
 import { useState } from 'react';
-import { Img, TextWrap } from '../../assets/styles/styles';
-import closeIcon from '../../assets/icons/close.svg';
-import { IconWrapper, ModalContent, ModalOpen } from './components/Modal';
-
+import { TextWrap } from '../../assets/styles/styles';
+import LoginModal from '../../components/LoginModal';
 const NoneLogin = () => {
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -33,34 +30,7 @@ const NoneLogin = () => {
       </Wrapper>
 
       {/* modal */}
-      <ReactModal
-        ariaHideApp={false}
-        isOpen={modalOpen}
-        onRequestClose={() => setModalOpen(false)}
-        style={{
-          overlay: {
-            position: 'fixed',
-            background: 'rgba(0, 0, 0, 0.3)',
-          },
-          content: {
-            margin: 'auto',
-            width: '815px',
-            height: '495px',
-            background: 'var(--type-white)',
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            borderRadius: '20px',
-          },
-        }}
-      >
-        <ModalOpen>
-          <IconWrapper onClick={() => setModalOpen(false)}>
-            <Img src={closeIcon} />
-          </IconWrapper>
-          <ModalContent />
-        </ModalOpen>
-      </ReactModal>
+      <LoginModal modalOpen={modalOpen} setModalOpen={setModalOpen} />
     </Container>
   );
 };


### PR DESCRIPTION
### Done 

구글로그인 Modal 관련된 것들을 src/components/LoginModal 폴더 아래에 위치시켰습니다!
메인 소스는 index.tsx에 있습니다.
메인 모달에서 modalOpen, setModalOpen props를 받아와서 모달을 호출하는 방식으로 구현했습니다.

### To - Do
any 타입을 바꾼다는게... 깜빡했네요.

```
interface Modal {
    modalOpen :  boolean;
    setModalOpen : React.Dispatch<React.SetStateAction<boolean>>;
}
```

를 추가하면 될 것 같습니당